### PR TITLE
Remove numpy 112 exclusion

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -11,7 +11,7 @@ source:
 
 build:
   number: 0
-  skip: True  # [win or np==112]
+  skip: True  # [win]
   script:
     - export LDFLAGS="-undefined dynamic_lookup -bundle"  # [osx]
     - python setup.py install

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -10,7 +10,7 @@ source:
   sha256: e287a7d1821d55a41079fe0289d70b6f2ea905f4c6b1a9207bdf35425bdcae37
 
 build:
-  number: 0
+  number: 1
   skip: True  # [win]
   script:
     - export LDFLAGS="-undefined dynamic_lookup -bundle"  # [osx]

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -19,11 +19,15 @@ build:
 requirements:
   build:
     - python
-    - numpy x.x
+    - numpy 1.8.*  # [not (win and (py35 or py36))]
+    - numpy 1.9.*  # [win and py35]
+    - numpy 1.11.*  # [win and py36]
     - gcc  # [not win]
   run:
     - python
-    - numpy x.x
+    - numpy >=1.8  # [not (win and (py35 or py36))]
+    - numpy >=1.9  # [win and py35]
+    - numpy >=1.11  # [win and py36]
     - scipy
     - matplotlib
     - libgcc  # [linux]


### PR DESCRIPTION
cc @fonnesbeck 

I don't know if this is permissible or not.  There were some reports of issues with np112 on Windows, but I'm not certain that those reports were observed on non-windows platforms.