### PR TITLE
Add test to check for warnings

### DIFF
--- a/recipe/allowed-warnings-base.txt
+++ b/recipe/allowed-warnings-base.txt
@@ -8,3 +8,4 @@ Could not locate executable ifl
 Could not locate executable f90
 Could not locate executable efl
 Using NumPy C-API based implementation for BLAS functions
+g++ not detected

--- a/recipe/allowed-warnings-base.txt
+++ b/recipe/allowed-warnings-base.txt
@@ -1,0 +1,10 @@
+# A list of regex for allowed warnings to ignore during testing of "pymc-base".
+# (More warnings are acceptable here since libraries will be missing.)
+
+Could not locate executable g77
+Could not locate executable f77
+Could not locate executable ifort
+Could not locate executable ifl
+Could not locate executable f90
+Could not locate executable efl
+Using NumPy C-API based implementation for BLAS functions

--- a/recipe/allowed-warnings-base.txt
+++ b/recipe/allowed-warnings-base.txt
@@ -8,4 +8,4 @@ Could not locate executable ifl
 Could not locate executable f90
 Could not locate executable efl
 Using NumPy C-API based implementation for BLAS functions
-g++ not detected
+g\+\+ not detected

--- a/recipe/allowed-warnings-main.txt
+++ b/recipe/allowed-warnings-main.txt
@@ -1,0 +1,3 @@
+# A list of regex for allowed warnings to ignore during testing of "pymc".
+
+PyMC is too cool for school

--- a/recipe/check-for-warnings.py
+++ b/recipe/check-for-warnings.py
@@ -1,7 +1,7 @@
 import re
 import subprocess
 
-RE_WARNING = re.compile("warning", re.IGNORECASE)
+RE_WARNING = re.compile("warn", re.IGNORECASE)
 
 ALLOWED_WARNINGS = [
     re.compile("PyMC is too cool for school")

--- a/recipe/check-for-warnings.py
+++ b/recipe/check-for-warnings.py
@@ -1,0 +1,36 @@
+import re
+import subprocess
+
+RE_WARNING = re.compile("warning", re.IGNORECASE)
+
+ALLOWED_WARNINGS = [
+    re.compile("PyMC is too cool for school")
+]
+
+result = subprocess.check_output(
+    ["python", "-c", "import pymc"],
+    stderr=subprocess.STDOUT
+)
+
+lines = result.decode().splitlines()
+warning_lines = [line for line in lines if RE_WARNING.search(line)]
+
+not_allowed_warning_lines = [
+    line for line in warning_lines
+    if not any(allowed.search(line) for allowed in ALLOWED_WARNINGS)
+]
+
+if len(not_allowed_warning_lines) > 0:
+    print("The following warnings were emitted but not allowed:")
+    print("\n    ".join([""] + not_allowed_warning_lines + [""]))
+    print(
+        "Please either fix them or add them to the ALLOWED_WARNINGS "
+        "list in check-for-warnings.py."
+    )
+    exit(1)
+else:
+    if len(warning_lines) > 0:
+        print("The following warnings were emitted, and are allowed:")
+        print("\n    ".join([""] + warning_lines + [""]))
+    else:
+        print("No warnings detected by check-for-warnings.py when importing pymc.")

--- a/recipe/check-for-warnings.py
+++ b/recipe/check-for-warnings.py
@@ -1,10 +1,18 @@
 import re
 import subprocess
+import sys
+from pathlib import Path
 
 RE_WARNING = re.compile("warn", re.IGNORECASE)
 
+if len(sys.argv) != 2:
+    print("Expecting a single command line argument with the list of allowed warnings.")
+    sys.exit(1)
+
+allowed_warnings_file_contents = Path(sys.argv[1]).read_text()
 ALLOWED_WARNINGS = [
-    re.compile("PyMC is too cool for school")
+    re.compile(line) for line in allowed_warnings_file_contents.splitlines()
+    if line.strip() and not line.strip().startswith("#")
 ]
 
 result = subprocess.check_output(

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -48,8 +48,11 @@ test:
     - pymc.ode
   commands:
     - pip check
+    - python check-for-warnings.py
   requires:
     - pip
+  files:
+    - check-for-warnings.py
 
 about:
   home: http://github.com/pymc-devs/pymc

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -9,7 +9,7 @@ source:
   sha256: 08cac213bf52d5a16b0aeef6ff6a312780a6a6ae935a2603fa607f4c105726af
 
 build:
-  number: 0
+  number: 1
   skip: true  # [py<37]
   script: {{ PYTHON }} -m pip install . -vv
 

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -15,7 +15,8 @@ build:
 outputs:
   - name: pymc-base
     build:
-      script: python -m pip install . -vv
+      script:
+        - python -m pip install . --no-deps -vv
     requirements:
       build:
         - python                                 # [build_platform != target_platform]
@@ -58,6 +59,7 @@ outputs:
       host:
         - python
       run:
+        - python
         - {{ pin_subpackage("pymc-base", exact=True) }}
         - cxx-compiler  # [not win]
         - m2w64-toolchain  # [win]

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -15,7 +15,7 @@ build:
 outputs:
   - name: pymc-base
     build:
-      script: {{ PYTHON }} -m pip install . -vv
+      script: python -m pip install . -vv
     requirements:
       build:
         - python                                 # [build_platform != target_platform]

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -11,48 +11,77 @@ source:
 build:
   number: 1
   skip: true  # [py<37]
-  script: {{ PYTHON }} -m pip install . -vv
 
-requirements:
-  build:
-    - python                                 # [build_platform != target_platform]
-    - cross-python_{{ target_platform }}     # [build_platform != target_platform]
-  host:
-    - python
-    - pip
-  run:
-    - python
-    - aesara ==2.6.6
-    - aeppl ==0.0.31
-    - arviz >=0.12.0
-    - cachetools >=4.2.1
-    - cloudpickle
-    - fastprogress >=0.2.0
-    - numpy >=1.15.0
-    - scipy >=1.4.1
-    - semver
-    - typing-extensions >=3.7.4
-    - cxx-compiler  # [not win]
-    - m2w64-toolchain  # [win]
-
-test:
-  imports:
-    - pymc
-    - pymc.backends
-    - pymc.distributions
-    - pymc.gp
-    - pymc.step_methods
-    - pymc.tests
-    - pymc.tuning
-    - pymc.variational
-    - pymc.ode
-  commands:
-    - pip check
-    - python check-for-warnings.py
-  requires:
-    - pip
-  files:
-    - check-for-warnings.py
+outputs:
+  - name: pymc-base
+    build:
+      script: {{ PYTHON }} -m pip install . -vv
+    requirements:
+      build:
+        - python                                 # [build_platform != target_platform]
+        - cross-python_{{ target_platform }}     # [build_platform != target_platform]
+      host:
+        - python
+        - pip
+      run:
+        - python
+        - aesara ==2.6.6
+        - aeppl ==0.0.31
+        - arviz >=0.12.0
+        - cachetools >=4.2.1
+        - cloudpickle
+        - fastprogress >=0.2.0
+        - numpy >=1.15.0
+        - scipy >=1.4.1
+        - semver
+        - typing-extensions >=3.7.4
+    test:
+      imports:
+        - pymc
+        - pymc.backends
+        - pymc.distributions
+        - pymc.gp
+        - pymc.step_methods
+        - pymc.tests
+        - pymc.tuning
+        - pymc.variational
+        - pymc.ode
+      commands:
+        - pip check
+        - python check-for-warnings.py allowed-warnings-base.txt
+      requires:
+        - pip
+      files:
+        - check-for-warnings.py
+        - allowed-warnings-base.txt
+  - name: pymc
+    requirements:
+      host:
+        - python
+      run:
+        - cxx-compiler  # [not win]
+        - m2w64-toolchain  # [win]
+        - mkl-service
+        - blas
+    test:
+      imports:
+        - pymc
+        - pymc.backends
+        - pymc.distributions
+        - pymc.gp
+        - pymc.step_methods
+        - pymc.tests
+        - pymc.tuning
+        - pymc.variational
+        - pymc.ode
+      commands:
+        - pip check
+        - python check-for-warnings.py allowed-warnings-main.txt
+      requires:
+        - pip
+      files:
+        - check-for-warnings.py
+        - allowed-warnings-main.txt
 
 about:
   home: http://github.com/pymc-devs/pymc

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -64,8 +64,10 @@ outputs:
         - {{ pin_subpackage("pymc-base", exact=True) }}
         - cxx-compiler  # [not win]
         - m2w64-toolchain  # [win]
-        - mkl-service
-        - blas
+        # BLAS:
+        # On Apple M1, use openblas, for everything else, use mkl-service.
+        - openblas # [arm64]
+        - mkl-service # [not arm64]
     test:
       imports:
         - pymc

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -58,6 +58,7 @@ outputs:
       host:
         - python
       run:
+        - {{ pin_subpackage("pymc-base", exact=True) }}
         - cxx-compiler  # [not win]
         - m2w64-toolchain  # [win]
         - mkl-service

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -26,8 +26,9 @@ outputs:
         - pip
       run:
         - python
-        - aesara ==2.6.6
+        # https://github.com/pymc-devs/pymc/blob/v{{ version }}/requirements.txt
         - aeppl ==0.0.31
+        - aesara ==2.6.6
         - arviz >=0.12.0
         - cachetools >=4.2.1
         - cloudpickle

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -66,8 +66,8 @@ outputs:
         - m2w64-toolchain  # [win]
         # BLAS:
         # On Apple M1, use openblas, for everything else, use mkl-service.
-        - openblas # [arm64]
-        - mkl-service # [not arm64]
+        - openblas  # [arm64]
+        - mkl-service  # [not arm64]
     test:
       imports:
         - pymc


### PR DESCRIPTION
Closes #40 by bumping build number

Adds a post-build test to ensure that `pymc` imports without warnings (e.g. compiler not found).

Attn: @michaelosthege 

<!--
Thank you for your pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [X] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [X] Bumped the build number (if the version is unchanged)
* [X] Reset the build number to `0` (if the version changed)
* [X] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [X] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->
