### PR TITLE
Keep releasing .tar.bz2 artifacts

### DIFF
--- a/conda-forge.yml
+++ b/conda-forge.yml
@@ -8,4 +8,5 @@ github:
 azure:
   store_build_artifacts: true
 conda_build:
-  pkg_format: '2'
+  pkg_format: 2    # makes .conda artifacts
+  pkg_format: None # makes .tar.bz2 artifacts

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -9,7 +9,7 @@ source:
   sha256: 5a8be78088e60232a3a2f5d76cb2eeb56d1ef62be5755ed61357c8f56506ee5f
 
 build:
-  number: 0
+  number: 1
 
 outputs:
   - name: pymc-base


### PR DESCRIPTION
This should fix installation on Windows where `mamba` currently does not offer the `.conda`-only releases.

Checklist
* [x] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [x] Bumped the build number (if the version is unchanged)
* [ ] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [x] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->
