### PR TITLE
Revert "add bot inspection"

### DIFF
--- a/conda-forge.yml
+++ b/conda-forge.yml
@@ -1,5 +1,3 @@
-bot:
-  inspection: update-grayskull
 build_platform:
   osx_arm64: osx_64
 conda_forge_output_validation: true


### PR DESCRIPTION
This reverts commit 0f652a9eb0f40f0cca314059a70b0524af5c2833.

Build number is deliberately not updated to prevent a new build.

@ocefpaf, it seems that 0f652a9eb0f40f0cca314059a70b0524af5c2833 is causing the auto-tick-bot to fail (#75). This is because `grayskull` is called with the package name [`attrs["name"]`](https://github.com/regro/cf-scripts/blob/7c3efae077e9a86488d41667ef9e843092e10ecf/conda_forge_tick/update_deps.py#L299) which comes from `package.name` in `meta.yaml`, in this case `pymc-suite` which is of course non-existent on PyPI.

It would be nice if auto-tick-bot would handle multi-output feedstocks (and it doesn't look so difficult). But until that happens let's revert.

<!--
Thank you for your pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [X] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [ ] Bumped the build number (if the version is unchanged)
* [ ] Reset the build number to `0` (if the version changed)
* [X] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [X] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->
